### PR TITLE
fix/4: Improve the way bounds are handled and add extra test cases

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,14 +1,17 @@
 module github.com/ryanolee/go-chaff
 
-go 1.21.0
+go 1.23.0
+
+require (
+	github.com/go-faker/faker/v4 v4.6.1
+	github.com/thoas/go-funk v0.9.3
+)
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/go-faker/faker/v4 v4.2.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/santhosh-tekuri/jsonschema v1.2.4 // indirect
 	github.com/stretchr/testify v1.8.4 // indirect
-	github.com/thoas/go-funk v0.9.3 // indirect
-	golang.org/x/text v0.3.7 // indirect
+	golang.org/x/text v0.28.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -3,6 +3,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/go-faker/faker/v4 v4.2.0 h1:dGebOupKwssrODV51E0zbMrv5e2gO9VWSLNC1WDCpWg=
 github.com/go-faker/faker/v4 v4.2.0/go.mod h1:F/bBy8GH9NxOxMInug5Gx4WYeG6fHJZ8Ol/dhcpRub4=
+github.com/go-faker/faker/v4 v4.6.1 h1:xUyVpAjEtB04l6XFY0V/29oR332rOSPWV4lU8RwDt4k=
+github.com/go-faker/faker/v4 v4.6.1/go.mod h1:arSdxNCSt7mOhdk8tEolvHeIJ7eX4OX80wXjKKvkKBY=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/santhosh-tekuri/jsonschema v1.2.4 h1:hNhW8e7t+H1vgY+1QeEQpveR6D4+OwKPXCfD2aieJis=
@@ -15,6 +17,8 @@ github.com/thoas/go-funk v0.9.3 h1:7+nAEx3kn5ZJcnDm2Bh23N2yOtweO14bi//dvRtgLpw=
 github.com/thoas/go-funk v0.9.3/go.mod h1:+IWnUfUmFO1+WVYQWQtIJHeRRdaIyyYglZN7xzUPe4Q=
 golang.org/x/text v0.3.7 h1:olpwvP2KacW1ZWvsR7uQhoyTYvKAupfQrRGBFM352Gk=
 golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
+golang.org/x/text v0.28.0 h1:rhazDwis8INMIwQ4tpjLDzUhx6RlXqZNPEM0huQojng=
+golang.org/x/text v0.28.0/go.mod h1:U8nCwOR8jO/marOQ0QbDiOngZVEBB7MAiitBuMjXiNU=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -1,5 +1,7 @@
 package util
 
+import "math"
+
 // Returns the first non-empty string
 func GetString(values ...string) string {
 	for _, value := range values {
@@ -31,6 +33,20 @@ func GetFloat(values ...float64) float64 {
 	}
 
 	return 0
+}
+
+func GetFloatPtr(values ...*float64) *float64 {
+	for _, value := range values {
+		if value != nil {
+			return value
+		}
+	}
+
+	return nil
+}
+
+func Round(x, unit float64) float64 {
+	return math.Round(x/unit) * unit
 }
 
 // Returns the true if value or defaultValue are true
@@ -66,3 +82,6 @@ func MinInt(a ...int) int {
 	return min
 }
 
+func FloatPtr(f float64) *float64 {
+	return &f
+}

--- a/merge.go
+++ b/merge.go
@@ -123,10 +123,10 @@ func mergeSchemaNodeSimpleProperties(baseNode schemaNode, otherNode schemaNode) 
 	baseNode.MaxLength = util.GetInt(otherNode.MaxLength, baseNode.MaxLength)
 
 	// Merge simple float properties
-	baseNode.Minimum = util.GetFloat(otherNode.Minimum, baseNode.Minimum)
-	baseNode.Maximum = util.GetFloat(otherNode.Maximum, baseNode.Maximum)
-	baseNode.ExclusiveMinimum = util.GetFloat(otherNode.ExclusiveMinimum, baseNode.ExclusiveMinimum)
-	baseNode.ExclusiveMaximum = util.GetFloat(otherNode.ExclusiveMaximum, baseNode.ExclusiveMaximum)
+	baseNode.Minimum = util.GetFloatPtr(otherNode.Minimum, baseNode.Minimum)
+	baseNode.Maximum = util.GetFloatPtr(otherNode.Maximum, baseNode.Maximum)
+	baseNode.ExclusiveMinimum = util.GetFloatPtr(otherNode.ExclusiveMinimum, baseNode.ExclusiveMinimum)
+	baseNode.ExclusiveMaximum = util.GetFloatPtr(otherNode.ExclusiveMaximum, baseNode.ExclusiveMaximum)
 	baseNode.MultipleOf = util.GetFloat(otherNode.MultipleOf, baseNode.MultipleOf)
 
 	// Merge simple string properties

--- a/number.go
+++ b/number.go
@@ -71,14 +71,13 @@ func parseNumber(node schemaNode, genType numberGeneratorType) (Generator, error
 	// Set default min and max if they are still infinite
 	// Or clamp them to be within a reasonable range of each other
 	offset := util.GetFloat(node.MultipleOf*100, defaultOffset)
-
-	if math.IsInf(min, 0) && !math.IsInf(max, 0) {
-		min = max - offset
-	} else if !math.IsInf(min, 0) && math.IsInf(max, 0) {
-		max = min + offset
-	} else if math.IsInf(min, 0) && math.IsInf(max, 0) {
-		min = -offset
+	if math.IsInf(min, -1) && math.IsInf(max, 1) {
+		min = 0
 		max = offset
+	} else if math.IsInf(min, -1) {
+		min = max - offset
+	} else if math.IsInf(max, 1) {
+		max = min + offset
 	}
 
 	// Finally clamp min and max to be within upper and lower bounds

--- a/number.go
+++ b/number.go
@@ -22,6 +22,7 @@ type (
 const (
 	infinitesimal = math.SmallestNonzeroFloat64
 
+	// Bound to slightly less than the max float64 value to avoid unserializable inf values
 	upperBound = math.MaxFloat64 / 1000
 	lowerBound = -(math.MaxFloat64 / 1000)
 

--- a/number_schema_test.go
+++ b/number_schema_test.go
@@ -1,0 +1,12 @@
+package chaff_test
+
+import (
+	"testing"
+
+	test "github.com/ryanolee/go-chaff/internal/test_utils"
+)
+
+func TestNumber(t *testing.T) {
+	t.Parallel()
+	test.TestJsonSchemaDir(t, "test_data/number", 100)
+}

--- a/number_test.go
+++ b/number_test.go
@@ -9,12 +9,10 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-
-
 func TestNumberGenerate(t *testing.T) {
-	
-	t.Run("Test int generation", func(t *testing.T){
-		testCases := [][] float64 {
+
+	t.Run("Test int generation", func(t *testing.T) {
+		testCases := [][]float64{
 			{0, 100},
 			{-100, 100},
 			{-100, 0},
@@ -22,12 +20,12 @@ func TestNumberGenerate(t *testing.T) {
 			{0, 1},
 			{1, 1},
 		}
-		
+
 		for _, testCase := range testCases {
-			t.Run(fmt.Sprintf("TestCase Min: %f max: %f", testCase[0], testCase[1]), func(t *testing.T){
+			t.Run(fmt.Sprintf("TestCase Min: %f max: %f", testCase[0], testCase[1]), func(t *testing.T) {
 				generator := &numberGenerator{
-					Min: testCase[0],
-					Max: testCase[1],
+					Min:  testCase[0],
+					Max:  testCase[1],
 					Type: generatorTypeInteger,
 				}
 
@@ -42,19 +40,19 @@ func TestNumberGenerate(t *testing.T) {
 		}
 	})
 
-	t.Run("Test float generation", func(t *testing.T){
-		testCases := [][] float64 {
+	t.Run("Test float generation", func(t *testing.T) {
+		testCases := [][]float64{
 			{-7.2, 8.5},
 			{-100, 100},
 			{-100, 0},
 			{0, 0.001},
 		}
-		
+
 		for _, testCase := range testCases {
-			t.Run(fmt.Sprintf("TestCase Min: %f max: %f", testCase[0], testCase[1]), func(t *testing.T){
+			t.Run(fmt.Sprintf("TestCase Min: %f max: %f", testCase[0], testCase[1]), func(t *testing.T) {
 				generator := &numberGenerator{
-					Min: testCase[0],
-					Max: testCase[1],
+					Min:  testCase[0],
+					Max:  testCase[1],
 					Type: generatorTypeNumber,
 				}
 
@@ -69,8 +67,8 @@ func TestNumberGenerate(t *testing.T) {
 		}
 	})
 
-	t.Run("Test Multiple Of Float", func(t *testing.T){
-		testCases := [][] float64 {
+	t.Run("Test Multiple Of Float", func(t *testing.T) {
+		testCases := [][]float64{
 			{0, 100, 10},
 			{-100, 100, 10},
 			{0, 100, 10},
@@ -80,20 +78,20 @@ func TestNumberGenerate(t *testing.T) {
 			{612.324, 2342.234, 7},
 			{612.324, 2342.234, 4.46},
 		}
-		
+
 		for _, testCase := range testCases {
-			t.Run(fmt.Sprintf("TestCase Min: %f max: %f, multiple: %f", testCase[0], testCase[1], testCase[2]), func(t *testing.T){
+			t.Run(fmt.Sprintf("TestCase Min: %f max: %f, multiple: %f", testCase[0], testCase[1], testCase[2]), func(t *testing.T) {
 				generator := &numberGenerator{
-					Min: testCase[0],
-					Max: testCase[1],
-					Type: generatorTypeNumber,
+					Min:        testCase[0],
+					Max:        testCase[1],
+					Type:       generatorTypeNumber,
 					MultipleOf: testCase[2],
 				}
 
 				result := generator.Generate(&GeneratorOptions{
 					Rand: rand.NewRandUtilFromTime(),
 				}).(float64)
-				
+
 				assert.GreaterOrEqual(t, result, testCase[0])
 				assert.LessOrEqual(t, result, testCase[1])
 				assert.IsType(t, float64(0), result)
@@ -102,17 +100,17 @@ func TestNumberGenerate(t *testing.T) {
 				// will return a number very close to the multiple of the number or 0
 				// This assertion handles that ... phun
 				res := math.Abs(testCase[2] - math.Mod(result, testCase[2]))
-				
-				if(res > 0.00001) {
-					res = math.Mod(result, testCase[2]);
+
+				if res > 0.00001 {
+					res = math.Mod(result, testCase[2])
 				}
-				
-				assert.Less(t, res, 0.00001)	
+
+				assert.Less(t, res, 0.00001)
 			})
 		}
 	})
 }
 
 func TestNumberParse(t *testing.T) {
-	t.Run("Test Invalid Min/Max", func(t *testing.T){})
+	t.Run("Test Invalid Min/Max", func(t *testing.T) {})
 }

--- a/parse.go
+++ b/parse.go
@@ -53,11 +53,11 @@ type (
 		MaxLength int    `json:"maxLength"`
 
 		// Number Properties
-		Minimum          float64 `json:"minimum"`
-		Maximum          float64 `json:"maximum"`
-		ExclusiveMinimum float64 `json:"exclusiveMinimum"`
-		ExclusiveMaximum float64 `json:"exclusiveMaximum"`
-		MultipleOf       float64 `json:"multipleOf"`
+		Minimum          *float64 `json:"minimum,omitempty"`
+		Maximum          *float64 `json:"maximum,omitempty"`
+		ExclusiveMinimum *float64 `json:"exclusiveMinimum,omitempty"`
+		ExclusiveMaximum *float64 `json:"exclusiveMaximum,omitempty"`
+		MultipleOf       float64  `json:"multipleOf"`
 
 		// Array Properties
 		Items    itemsData `json:"items"`
@@ -296,10 +296,10 @@ func inferType(node schemaNode) string {
 	}
 
 	// Number Properties
-	if node.Minimum != 0 ||
-		node.Maximum != 0 ||
-		node.ExclusiveMinimum != 0 ||
-		node.ExclusiveMaximum != 0 ||
+	if node.Minimum != nil ||
+		node.Maximum != nil ||
+		node.ExclusiveMinimum != nil ||
+		node.ExclusiveMaximum != nil ||
 		node.MultipleOf != 0 {
 		return typeNumber
 	}

--- a/test_data/number/number_bounds.json
+++ b/test_data/number/number_bounds.json
@@ -1,0 +1,63 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "properties": {
+        "test_integer_basic": { "type": "integer" },
+        "test_number_basic": { "type": "number" },
+
+        "test_zero": { "type": "number", "const": 0 },
+
+        "test_min_inclusive": { "type": "number", "minimum": -100 },
+        "test_min_exclusive": { "type": "number", "exclusiveMinimum": -100 },
+        "test_max_inclusive": { "type": "number", "maximum": 100 },
+        "test_max_exclusive": { "type": "number", "exclusiveMaximum": 100 },
+
+        "test_range_inclusive": { "type": "number", "minimum": -10, "maximum": 10 },
+        "test_range_exclusive": { "type": "number", "exclusiveMinimum": -10, "exclusiveMaximum": 10 },
+        "test_mixed_boundaries": { "type": "number", "minimum": 1, "exclusiveMaximum": 5 },
+
+        "test_large_integer": { "type": "integer", "minimum": -9007199254740991, "maximum": 9007199254740991 },
+        "test_very_large_number": { "type": "number", "minimum": -1e308, "maximum": 1e308 },
+        "test_small_magnitude": { "type": "number", "minimum": -1e-308, "maximum": 1e-308 },
+
+        "test_multiple_of_integer": { "type": "integer", "multipleOf": 7 },
+        "test_multiple_of_power_two": { "type": "integer", "multipleOf": 1024 },
+
+        "test_positive_integer_range": { "type": "integer", "minimum": 1, "maximum": 1000 },
+        "test_negative_integer_range": { "type": "integer", "minimum": -1000, "maximum": -1 },
+
+        "test_positive_or_zero": { "type": "number", "minimum": 0 },
+        "test_negative_or_zero": { "type": "number", "maximum": 0 },
+
+        "test_small_positive_fraction": { "type": "number", "minimum": 0.0000001, "maximum": 0.0001 },
+        "test_small_negative_fraction": { "type": "number", "minimum": -0.0001, "maximum": -0.0000001 },
+
+        "test_open_interval_near_zero": { "type": "number", "exclusiveMinimum": -1, "exclusiveMaximum": 1 },
+
+        "test_chained_constraints": {
+            "type": "number",
+            "minimum": 10,
+            "maximum": 1000,
+            "multipleOf": 2
+        },
+
+        "test_extreme_signed_32": { "type": "integer", "minimum": -2147483648, "maximum": 2147483647 },
+        "test_extreme_unsigned_32": { "type": "integer", "minimum": 0, "maximum": 4294967295 },
+
+        "test_extreme_signed_64": { "type": "integer", "minimum": -9223372036854775808, "maximum": 9223372036854775807 },
+
+        "test_power_of_ten_span": { "type": "number", "minimum": 1e-12, "maximum": 1e12 },
+
+        "test_boundary_at_one": { "type": "number", "minimum": 1, "exclusiveMaximum": 2 },
+        "test_boundary_below_one": { "type": "number", "exclusiveMinimum": 0, "maximum": 1 },
+
+        "test_round_trip_safe_int": { "type": "integer", "minimum": -9007199254740991, "maximum": 9007199254740991 },
+
+        "test_multiple_of_fraction": { "type": "number", "multipleOf": 0.125, "minimum": 0, "maximum": 2 },
+
+        "test_denormal_like": { "type": "number", "minimum": 5e-324, "maximum": 1e-320 },
+
+        "test_close_to_one": { "type": "number", "minimum": 0.999999, "maximum": 1.000001 }
+    },
+    "additionalProperties": false
+}

--- a/test_data/number/number_bounds.json
+++ b/test_data/number/number_bounds.json
@@ -28,6 +28,13 @@
 
         "test_positive_or_zero": { "type": "number", "minimum": 0 },
         "test_negative_or_zero": { "type": "number", "maximum": 0 },
+        
+        "test_negative_min_inclusive": { "type": "number", "minimum": -1000 },
+        "test_negative_max_inclusive": { "type": "number", "maximum": -1 },
+        "test_negative_range_inclusive": { "type": "number", "minimum": -1000, "maximum": -1 },
+        "test_negative_max_exclusive": { "type": "number", "exclusiveMaximum": -1 },
+        "test_negative_min_exclusive": { "type": "number", "exclusiveMinimum": -1000 },
+        "test_negative_range_exclusive": { "type": "number", "exclusiveMinimum": -1000, "exclusiveMaximum": -1 },
 
         "test_small_positive_fraction": { "type": "number", "minimum": 0.0000001, "maximum": 0.0001 },
         "test_small_negative_fraction": { "type": "number", "minimum": -0.0001, "maximum": -0.0000001 },


### PR DESCRIPTION
# What
Following up from #4  there is no distinction between 0 and no passed value for minimum and maximums.  In order to resolve this a distinction has now been made between nil and 0 specifically.

# Why
The lack of this distinction was causing problems

# How
By properly bounding the minimum and maximum an representing the lack of a specified value as 0 we bound to either a `minimum` / `maximum` if specified or a reasonable default if not set. Added new test cases to cover this also in the event if is not defined