### PR TITLE
fix(4): Fix issues with the integer number type

### DIFF
--- a/test_data/number/number_bounds.json
+++ b/test_data/number/number_bounds.json
@@ -36,6 +36,13 @@
         "test_negative_min_exclusive": { "type": "number", "exclusiveMinimum": -1000 },
         "test_negative_range_exclusive": { "type": "number", "exclusiveMinimum": -1000, "exclusiveMaximum": -1 },
 
+        "test_min_integer": { "type": "integer", "minimum": -100 },
+        "test_max_integer": { "type": "integer", "maximum": 100},
+        "test_exclusive_min_integer": { "type": "integer", "exclusiveMinimum": -100 },
+        "test_exclusive_max_integer": { "type": "integer", "exclusiveMaximum": 100},
+
+        "test_matching_bounds": { "type": "number", "minimum": 42, "maximum": 42 },
+
         "test_small_positive_fraction": { "type": "number", "minimum": 0.0000001, "maximum": 0.0001 },
         "test_small_negative_fraction": { "type": "number", "minimum": -0.0001, "maximum": -0.0000001 },
 


### PR DESCRIPTION
# What
Issues with float values and more specifically floating point precision when generating values causes some problems when generating random numbers

# Why
See https://github.com/ryanolee/go-chaff/issues/4#issuecomment-3265749087

# How this fixes it
Limits precision to 14 decimal places so go langs math lib's do not implode